### PR TITLE
Quick Fixes for CSR-loading to take events as args.

### DIFF
--- a/event/io/csr.py
+++ b/event/io/csr.py
@@ -909,12 +909,18 @@ class CSR:
                 else:
                     event_types = handle_xor(raw_type)
                     
-                # quick fix by using only the first realis
+                # quick fix by preferring realis from zie component
                 raw_realis = interp.get("realis", None)
                 if raw_realis is None or isinstance(raw_realis, str):
                     event_realis = raw_realis
                 else:
-                    event_realis = handle_xor(raw_realis)[0]
+                    if isinstance(raw_realis, dict):
+                        cand_realis = [g['value'] for g in raw_realis['args'] if g.get('component','').startswith("zie.")]
+                    else:
+                        cand_realis = [g['value'] for g in raw_realis if g.get('component','').startswith("zie.")]
+                    if len(cand_realis)==0:  # use all if not found
+                        cand_realis = handle_xor(raw_realis)
+                    event_realis = cand_realis[-1]
 
                 for t in event_types:
                     csr_evm = self.add_event_mention(

--- a/event/io/csr.py
+++ b/event/io/csr.py
@@ -908,15 +908,22 @@ class CSR:
                     event_types = [raw_type]
                 else:
                     event_types = handle_xor(raw_type)
+                    
+                # quick fix by using only the first realis
+                raw_realis = interp.get("realis", None)
+                if raw_realis is None or isinstance(raw_realis, str):
+                    event_realis = raw_realis
+                else:
+                    event_realis = handle_xor(raw_realis)[0]
 
                 for t in event_types:
                     csr_evm = self.add_event_mention(
-                        span, span, text, t, realis=interp.get('realis', None),
+                        span, span, text, t, realis=event_realis,
                         parent_sent=parent_sent, component=frame['component'],
                         event_id=frame['@id']
                     )
                     
-                    entities_or_events[event_id] = csr_evm
+                    entities_or_events[frame['@id']] = csr_evm
 
                 for mod, v in frame["provenance"]["modifiers"].items():
                     csr_evm.add_modifier(mod, v)


### PR DESCRIPTION
As the title suggests:
1. Mainly fix for CSR-loading to handle cases where args are events.

Also including other two:
2.1 A quick but dirty fix to include only one realis value if there are multiple.
2.2 Update for `zie_integration_utils.py`

Note: I only test this with `csr/event/io/csr2stuff.py` by converting CSR to Brat, please also test for other cases, especially the following several steps in the pipeline.
