### PR TITLE
Add an option of 'evt_merge_level'.

### DIFF
--- a/conf/aida/combine.py
+++ b/conf/aida/combine.py
@@ -54,6 +54,8 @@ c.CombineParams.ignore_comex = False
 # zie
 c.CombineParams.zie_event = os.path.join(os.path.dirname(os.path.dirname(output_base+"/")), 'zie', f'zie.{c.DetectionParams.language}_out')
 
+# by default, merge without considering types (level=0)
+c.CombineParams.evt_merge_level = 0
 
 # This is the parent child from the eval source.
 if 'parent_child_tab' in os.environ:

--- a/conf/aida/combine_no_rich_event.py
+++ b/conf/aida/combine_no_rich_event.py
@@ -54,6 +54,8 @@ c.CombineParams.ignore_comex = False
 # zie
 c.CombineParams.zie_event = os.path.join(os.path.dirname(os.path.dirname(output_base+"/")), 'zie', f'zie.{c.DetectionParams.language}_out')
 
+# by default, merge without considering types (level=0)
+c.CombineParams.evt_merge_level = 0
 
 # This is the parent child from the eval source.
 if 'parent_child_tab' in os.environ:

--- a/event/mention/combine_runner.py
+++ b/event/mention/combine_runner.py
@@ -8,6 +8,7 @@ import os
 from traitlets import (
     Unicode,
     Bool,
+    Integer,
 )
 from traitlets.config.loader import PyFileConfigLoader
 from event.mention.params import DetectionParams
@@ -540,7 +541,7 @@ def analyze_sentence(text):
 
 
 def read_source(source_folder, language, ontology, child2root,
-                csr_component_name, use_ltf_span_style=False):
+                csr_component_name, use_ltf_span_style=False, evt_merge_level=0):
     for source_text_path in glob.glob(source_folder + '/*.txt'):
         # Use the empty newline to handle different newline format.
         with open(source_text_path, newline='') as text_in:
@@ -549,7 +550,7 @@ def read_source(source_folder, language, ontology, child2root,
             runid = time.strftime("%Y%m%d%H%M")
 
             csr = CSR(csr_component_name, runid, 'data',
-                      ontology=ontology)
+                      ontology=ontology, evt_merge_level=evt_merge_level)
 
             # Find the root if possible, otherwise use itself.
             if docid in child2root:
@@ -777,7 +778,8 @@ def main(config):
     for csr, docid in read_source(config.source_folder, config.language,
                                   ontology, child2root,
                                   'Frames_hector_combined',
-                                  config.use_ltf_span_style):
+                                  config.use_ltf_span_style,
+                                  config.evt_merge_level):
         logging.info('Working with docid: {}'.format(docid))
 
         if config.edl_json and not ignore_edl:
@@ -920,6 +922,11 @@ class CombineParams(DetectionParams):
     extent_based_provenance = Bool(
         help='disable extent based provenance for event mentions to use trigger based provenance',
         default_value=True).tag(config=True)
+
+    evt_merge_level = Integer(
+        help='How much level of type level to consider when merge events',
+        default_value=0
+    ).tag(config=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add an option of 'evt_merge_level', which allows event merging only 1) span or head-span match, 2) Leveled-type match.
By default, this is set to 0, which means 2) is not effective, giving the same strategy as previous.

We can try with `--CombineParams.evt_merge_level=0` and `--CombineParams.evt_merge_level=1`.

Cautions:
1. Not sure how this affects later steps, since there can be events with **EXACTLY** the same span, but not merged inside one frame.
2. This feature has to be specified when intializing CSR, thus if any other components are using the CSR-API rather than directly dealing with json, things may get merged again. (Currently no other places are using CSR-API?)
