### PR TITLE
Allow time arg for rel.

### DIFF
--- a/event/zie_integration_utils.py
+++ b/event/zie_integration_utils.py
@@ -118,7 +118,7 @@ def add_zie_event(zie_event_file, csr):
                 rel_type = "ldcOnt:" + rel["type"].split(":")[-1]
                 rel_arg_ids, rel_arg_roles = [], []
                 for arg in rel["em_arg"]:
-                    if not arg["role"].startswith("rel:"):
+                    if not (arg["role"].startswith("rel:") or arg["role"].startswith("aida:")):
                         continue
                     # find the arg
                     arg_extra_info = arg["extra_info"]
@@ -136,11 +136,11 @@ def add_zie_event(zie_event_file, csr):
                         logging.warning(f"Adding rel_arg failed for {arg})")
                         continue
                     # put it
-                    arg_role = f"{rel_type}_{arg['role'].split(':')[-1]}"
+                    arg_role = arg['role'] if arg["role"].startswith("aida:") else f"{rel_type}_{arg['role'].split(':')[-1]}"
                     rel_arg_ids.append(one_arg.id)
                     rel_arg_roles.append(arg_role)
                 # finally checking
-                if len(rel_arg_ids) == 2:
+                if len(rel_arg_ids) >= 2:  # allow extra ones for time
                     # finally adding
                     csr_rel = csr.add_relation(
                         arguments=rel_arg_ids, arg_names=rel_arg_roles,


### PR DESCRIPTION
Together with the update on event-pipeline: [here](https://github.com/edvisees/opera-TA1-event/commit/d4b048c95f03ddaf59a30b481a3965931a14b1e1).

Using heuristic rules for finding time-arg for blame-relations and add them to csr.
The format is similar to the event ones, see `rabat:/data2/zhisongz/working/zop20/simul_root/ven20v3/output1011/english/csr/IC001VBJL.csr.json#L9428` for an example, or here:

![图片](https://user-images.githubusercontent.com/12146674/95693213-304c4880-0bf9-11eb-856b-265e3d44e141.png)

By the way, now relations can have >=2 arguments (a possible additional `aida:time` one).